### PR TITLE
Message formatting choices

### DIFF
--- a/pg_telegram/__init__.py
+++ b/pg_telegram/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from pg_telegram.tasks import run_tg_bot
 

--- a/pg_telegram/tasks.py
+++ b/pg_telegram/tasks.py
@@ -100,6 +100,7 @@ async def tg_send(client, bot, entries, box):
         for b_channel in bot["details"]["tgbot"]["channels"]:
             for entity in entities:
                 await client.send_message(b_channel, entity)
+                await client.send_message(b_channel, entity, parse_mode='html', link_preview=True)
             await box.update_one(
                 {'_id': entry._id},
                 {'$set': {"tg_sent": True}}

--- a/pg_telegram/tasks.py
+++ b/pg_telegram/tasks.py
@@ -92,14 +92,13 @@ async def run_tg_bot(app):
 
 async def tg_send(client, bot, entries, box):
     for entry in entries:
-        attachments = entry.activity['object'].get('attachment', [])
-        entities = [attachment['url'] for attachment in attachments]
-        content = entry.activity['object']['content']
-        if content:
-            entities.append(content)
+        # url of original entry is sufficient if we do link_preview
+        url = entry.activity['object']['url']
+        entities = []
+        if url:
+            entities.append(url)
         for b_channel in bot["details"]["tgbot"]["channels"]:
             for entity in entities:
-                await client.send_message(b_channel, entity)
                 await client.send_message(b_channel, entity, parse_mode='html', link_preview=True)
             await box.update_one(
                 {'_id': entry._id},


### PR DESCRIPTION
- `parse_mode=html` is a good choice for all sources so, that can be set in any case (at least with the usecases I know it's a good default) 
- `link_preview=True` is a bit more  complex and really should be configurable per source.

Source data:
- activity.object.`url` => back link to source activity, this should probably come first in the message 
- activity.object.`content` -> typically html content 
- activity.object.`attachment` -> array of media urls

There are 2 things to work out:

1. which of the source data elements need to be in the message
2. do we want `link_preview`, which takes the first link in the message content and uses some telegram magic to create a preview of the destination (not always possible)

Analysis for my usecases:

- `url`  should be the first in the message to link back to the source content.
- if `link_preview` is OFF we should add `content`, otherwise it will just be the link
- if `link_preview` is ON the content is most likely rendered for us automatically (and Telegram mostly does the right thing)

Ignoring `attachment` for now, this pleads for having `link_preview` set to ON for all incoming messages and just using the `url` as content after which Telegram takes care of the rest.

If attachments come into play we can:
1. ignore them and have the user visit the source
2. post a separate message per attachment (a link) with `link_preview` choices as above 
3. include them in the message (so we don't get a bombardment of messages, but just one)


Ideal situation would be a templated configuration per 'follow', but this may be too much.

For me personally, a configuration where the message content is just `url` with 'link_preview=True` and ignoring attachments would be just fine for me.




